### PR TITLE
Make "Explain like I'm..." prompt slightly more abstract

### DIFF
--- a/data/prompts.ts
+++ b/data/prompts.ts
@@ -427,9 +427,9 @@ const misc: Prompt[] = [
   },
   {
     id: "eli",
-    title: "Explain Like I'm...",
+    title: "Explain Like I'm a...",
     prompt:
-      "Explain the text like I’m a {argument name=age default=5} year old." +
+      `Explain the text like I’m a {argument name=identity default="5 year old"}` +
       generateSelection("Text", "Explanation"),
     creativity: "low",
     icon: "book",


### PR DESCRIPTION
Feel free to reject, but thought this would be a fun change since it allows entirely different identities.