### PR TITLE
Add focus state logo button

### DIFF
--- a/pages/[[...slug]].tsx
+++ b/pages/[[...slug]].tsx
@@ -277,12 +277,10 @@ export default function Home({ onTouchReady }) {
       <header className={styles.nav}>
         <Dialog open={aboutOpen} onOpenChange={setAboutOpen}>
           <DialogTrigger asChild>
-            <button style={{ all: "unset" }}>
-              <div className={styles.logo}>
-                <RaycastLogoNegIcon />
-                <div className={styles.separator} aria-hidden="true"></div>
-                <h2>Prompt Explorer</h2>
-              </div>
+            <button className={styles.logo}>
+              <RaycastLogoNegIcon />
+              <div className={styles.logoSeparator} aria-hidden="true"></div>
+              <h2>Prompt Explorer</h2>
             </button>
           </DialogTrigger>
           <DialogContent className={styles.about} showCloseButton={true}>

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -469,13 +469,15 @@
 }
 
 .logo {
+  all: unset;
   position: relative;
   display: flex;
   align-items: center;
   gap: 8px;
   cursor: pointer;
 
-  &:hover {
+  &:hover,
+  &:focus-visible {
     background-color: #282b3580;
     border-radius: 8px;
   }
@@ -484,11 +486,6 @@
     width: 30px;
     height: 30px;
     color: #ff6363;
-  }
-
-  .separator {
-    height: 30px;
-    border-right: 1px solid #282b35;
   }
 
   h2 {
@@ -505,6 +502,11 @@
       height: 36px;
     }
   }
+}
+
+.logoSeparator {
+  height: 30px;
+  border-right: 1px solid #282b35;
 }
 
 .about {


### PR DESCRIPTION
Adding a focus state to the logo button. The styles are the same as the hover ones.

Adding an outline ring would be even better, but at least this adds a visual cue.

|before|after|
|---|---|
|![before](https://github.com/raycast/prompt-explorer/assets/7225802/7172a4e0-051a-4c70-8248-9a9198e05376)|![after](https://github.com/raycast/prompt-explorer/assets/7225802/16c901ec-9ae5-4627-9c27-d07fdd92a06d)|
